### PR TITLE
Adding support for getting public keys for JWTs from OIDC

### DIFF
--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -185,6 +185,9 @@ var Config = struct {
 	// "HS256" and "RS256" supported
 	JWTAuthSigningMethod string `env:"FLAGR_JWT_AUTH_SIGNING_METHOD" envDefault:"HS256"`
 
+	// Verify the JWT through OIDC flows
+	JWTAuthOIDCWellKnownURL string `env:"FLAGR_JWT_AUTH_OIDC_WELL_KNOWN_URL" envDefault:""`
+
 	// Identify users through headers
 	HeaderAuthEnabled   bool   `env:"FLAGR_HEADER_AUTH_ENABLED" envDefault:"false"`
 	HeaderAuthUserField string `env:"FLAGR_HEADER_AUTH_USER_FIELD" envDefault:"X-Email"`

--- a/pkg/config/middleware.go
+++ b/pkg/config/middleware.go
@@ -188,10 +188,6 @@ func setupJWTAuthMiddleware() *jwtAuth {
 				return "", err
 			}
 
-			if err != nil {
-				return "", err
-			}
-
 			// Read in the jwks and unmarshall it.
 			defer oidcJwksResp.Body.Close()
 			body, err = ioutil.ReadAll(oidcJwksResp.Body)


### PR DESCRIPTION
Many JWTs provided through OAuth flows have rotating public keys that are provided through OIDC flows. Given a configuration URL, we can determine what the appropriate public key for a JWT should be. I've only tested this with Azure AD as an identity provider, but the flow should work for any RSA signed JWT. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.