### PR TITLE
Stripping the eval context from batch responses in order to reduce th…

### DIFF
--- a/docs/api_docs/bundle.yaml
+++ b/docs/api_docs/bundle.yaml
@@ -1197,6 +1197,9 @@ definitions:
         minItems: 1
       enableDebug:
         type: boolean
+      stripEvalContext:
+        type: boolean
+        default: false
       flagIDs:
         description: flagIDs
         type: array

--- a/pkg/handler/eval_test.go
+++ b/pkg/handler/eval_test.go
@@ -146,7 +146,7 @@ func TestEvalFlag(t *testing.T) {
 
 	t.Run("test empty evalContext", func(t *testing.T) {
 		defer gostub.StubFunc(&GetEvalCache, GenFixtureEvalCache()).Reset()
-		result := EvalFlag(models.EvalContext{FlagID: int64(100)})
+		result := EvalFlag(models.EvalContext{FlagID: int64(100)}, false)
 		assert.Zero(t, result.VariantID)
 		assert.NotZero(t, result.FlagID)
 		assert.NotEmpty(t, result.EvalContext.EntityID)
@@ -160,7 +160,7 @@ func TestEvalFlag(t *testing.T) {
 			EntityID:      "entityID1",
 			EntityType:    "entityType1",
 			FlagID:        int64(100),
-		})
+		}, false)
 		assert.NotNil(t, result)
 		assert.NotNil(t, result.VariantID)
 	})
@@ -173,7 +173,7 @@ func TestEvalFlag(t *testing.T) {
 			EntityID:      "entityID1",
 			EntityType:    "entityType1",
 			FlagKey:       "flag_key_100",
-		})
+		}, false)
 		assert.NotNil(t, result)
 		assert.NotNil(t, result.VariantID)
 	})
@@ -186,7 +186,7 @@ func TestEvalFlag(t *testing.T) {
 			EntityID:      "entityID1",
 			EntityType:    "entityType1",
 			FlagKey:       "flag_key_100",
-		})
+		}, false)
 		assert.NotNil(t, result)
 		assert.NotNil(t, result.VariantID)
 	})
@@ -225,7 +225,7 @@ func TestEvalFlag(t *testing.T) {
 			EntityID:      "entityID1",
 			EntityType:    "entityType1",
 			FlagID:        int64(100),
-		})
+		}, false)
 		assert.NotNil(t, result)
 		assert.NotNil(t, result.VariantID)
 	})
@@ -245,7 +245,7 @@ func TestEvalFlag(t *testing.T) {
 			EntityID:      "entityID1",
 			EntityType:    "entityType1",
 			FlagID:        int64(100),
-		})
+		}, false)
 		assert.NotNil(t, result)
 		assert.Zero(t, result.VariantID)
 	})
@@ -277,7 +277,7 @@ func TestEvalFlag(t *testing.T) {
 			EntityID:      "entityID1",
 			EntityType:    "entityType1",
 			FlagID:        int64(100),
-		})
+		}, false)
 		assert.NotNil(t, result)
 		assert.Zero(t, result.VariantID)
 	})
@@ -293,7 +293,7 @@ func TestEvalFlag(t *testing.T) {
 			EntityID:      "entityID1",
 			EntityType:    "entityType1",
 			FlagID:        int64(100),
-		})
+		}, false)
 		assert.NotNil(t, result)
 		assert.Zero(t, result.VariantID)
 	})
@@ -310,7 +310,7 @@ func TestEvalFlag(t *testing.T) {
 				EntityID:      "entityID1",
 				EntityType:    "entityType1",
 				FlagID:        int64(100),
-			})
+			}, false)
 			assert.NotNil(t, result)
 			assert.NotNil(t, result.VariantID)
 			assert.Equal(t, "entityType1", result.EvalContext.EntityType)
@@ -326,7 +326,7 @@ func TestEvalFlag(t *testing.T) {
 				EntityID:      "entityID1",
 				EntityType:    "entityType1",
 				FlagID:        int64(100),
-			})
+			}, false)
 			assert.NotNil(t, result)
 			assert.NotNil(t, result.VariantID)
 			assert.NotEqual(t, "entityType1", result.EvalContext.EntityType)

--- a/swagger/index.yaml
+++ b/swagger/index.yaml
@@ -485,6 +485,9 @@ definitions:
         minItems: 1
       enableDebug:
         type: boolean
+      stripEvalContext:
+        type: boolean
+        default: false
       flagIDs:
         description: flagIDs
         type: array

--- a/swagger_gen/models/evaluation_batch_request.go
+++ b/swagger_gen/models/evaluation_batch_request.go
@@ -34,6 +34,9 @@ type EvaluationBatchRequest struct {
 	// flagKeys. Either flagIDs or flagKeys works. If pass in both, Flagr may return duplicate results.
 	// Min Items: 1
 	FlagKeys []string `json:"flagKeys"`
+
+	// strip eval context
+	StripEvalContext *bool `json:"stripEvalContext,omitempty"`
 }
 
 // Validate validates this evaluation batch request

--- a/swagger_gen/restapi/embedded_spec.go
+++ b/swagger_gen/restapi/embedded_spec.go
@@ -1424,6 +1424,10 @@ func init() {
             "type": "string",
             "minLength": 1
           }
+        },
+        "stripEvalContext": {
+          "type": "boolean",
+          "default": false
         }
       }
     },
@@ -3203,6 +3207,10 @@ func init() {
             "type": "string",
             "minLength": 1
           }
+        },
+        "stripEvalContext": {
+          "type": "boolean",
+          "default": false
         }
       }
     },


### PR DESCRIPTION
Removing Eval Context from Batch Evaluation Responses.

## Description
Providing an optional parameter on the batch evaluation request to remove the eval context from the response. This context was already provided by the client when making the request, and returning it doesn't seem necessary, and more importantly, drastically increases the size of the response when providing any sufficiently large context. It especially is difficult when evaluating a large amount of flags or entities, since the context is returned for each flag and for each entity, further exacerbating the issue. 

## Motivation and Context
Reducing the size of the response when performing a batch evaluation. 

## How Has This Been Tested?
Verified in builds, no unit tests were added.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ x ] My code follows the code style of this project.
- [ x ] My change requires a change to the documentation.
- [ x ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.